### PR TITLE
Port to GNOME 45

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,8 +3,10 @@
   "description": "Mullvad connection status indicator",
   "uuid": "mullvadindicator@pobega.github.com",
   "shell-version": [
-    "44"
+    "45"
   ],
   "url": "https://github.com/Pobega/gnome-shell-extension-mullvad-indicator",
-  "version": 11.0
+  "settings-schema": "org.gnome.shell.extensions.MullvadIndicator",
+  "gettext-domain": "mullvadindicator@pobega.github.com",
+  "version": 12.0
 }

--- a/metadata.json
+++ b/metadata.json
@@ -8,5 +8,5 @@
   "url": "https://github.com/Pobega/gnome-shell-extension-mullvad-indicator",
   "settings-schema": "org.gnome.shell.extensions.MullvadIndicator",
   "gettext-domain": "mullvadindicator@pobega.github.com",
-  "version": 12.0
+  "version": 15.0
 }

--- a/mullvad.js
+++ b/mullvad.js
@@ -1,10 +1,11 @@
-const {GLib, GObject, Gio, Soup} = imports.gi;
-const Gettext = imports.gettext.domain('mullvadindicator');
+import GLib from 'gi://GLib';
+import GObject from 'gi://GObject';
+import Gio from 'gi://Gio';
+import Soup from 'gi://Soup';
+
+import {domain as gettextDomain} from 'gettext';
+const Gettext = gettextDomain('mullvadindicator@pobega.github.com');
 const _ = Gettext.gettext;
-
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-
-const ExtensionUtils = imports.misc.extensionUtils;
 
 const DEFAULT_ITEMS = {
     server: {name: _('Server'), text: '', gSetting: 'show-server'},
@@ -18,13 +19,11 @@ const ITEMS_ENUMERATED = [
     'server', 'country', 'city', 'ip', 'type',
 ];
 
-function statusItemNames() {
+export function statusItemNames() {
     return ITEMS_ENUMERATED.map((item_enum) => DEFAULT_ITEMS[item_enum].name);
 }
 
-
-
-var MullvadVPN = GObject.registerClass({
+export const MullvadVPN = GObject.registerClass({
     GTypeName: 'MullvadVPN',
     Properties: {
         'connected': GObject.ParamSpec.string('connected',
@@ -40,10 +39,10 @@ var MullvadVPN = GObject.registerClass({
         'status-changed': {},
     },
 }, class MullvadVPN extends GObject.Object {
-    _init(params = {}) {
+    _init(settings, params = {}) {
         super._init(params);
 
-        this._settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.MullvadIndicator');
+        this._settings = settings;
 
         this._networkMonitor = Gio.NetworkMonitor.get_default();
         this._httpSession = new Soup.Session();

--- a/prefs.js
+++ b/prefs.js
@@ -1,28 +1,21 @@
-const {Adw, Gio, GObject, Gtk} = imports.gi;
-const Gettext = imports.gettext.domain('mullvadindicator');
-const _ = Gettext.gettext;
+import Adw from 'gi://Adw';
+import Gio from 'gi://Gio';
+import Gtk from 'gi://Gtk';
 
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-const Mullvad = Me.imports.mullvad;
+import * as Mullvad from './mullvad.js';
 
-const ExtensionUtils = imports.misc.extensionUtils;
+import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
+export default class MullvadIndicatorPreferences extends ExtensionPreferences {
+    fillPreferencesWindow(window) {
+        this._settings = this.getSettings();
 
-
-class MullvadIndicatorPrefsWidget extends Adw.PreferencesPage {
-    static {
-        GObject.registerClass(this);
-    }
-
-    constructor() {
-        super();
-
-        this._settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.MullvadIndicator');
+        const page = new Adw.PreferencesPage();
 
         let group = new Adw.PreferencesGroup({
             title: _('Visibility'),
         });
-        this.add(group);
+        page.add(group);
 
         group.add(this._actionRow(_('Display indicator icon'), 'show-icon', new Gtk.Switch(), 'active'));
         group.add(this._actionRow(_('Show in system menu'), 'show-menu', new Gtk.Switch(), 'active'));
@@ -32,7 +25,7 @@ class MullvadIndicatorPrefsWidget extends Adw.PreferencesPage {
         group = new Adw.PreferencesGroup({
             title: _('Refresh'),
         });
-        this.add(group);
+        page.add(group);
 
         let spinButton = new Gtk.SpinButton();
         spinButton.set_range(1, 9999);
@@ -43,13 +36,15 @@ class MullvadIndicatorPrefsWidget extends Adw.PreferencesPage {
         group = new Adw.PreferencesGroup({
             title: _('Status'),
         });
-        this.add(group);
+        page.add(group);
 
         group.add(this._actionRow(_('Show currently connected server'), 'show-server', new Gtk.Switch(), 'active'));
         group.add(this._actionRow(_("Show currently connected server's country"), 'show-country', new Gtk.Switch(), 'active'));
         group.add(this._actionRow(_("Show currently connected server's city"), 'show-city', new Gtk.Switch(), 'active'));
         group.add(this._actionRow(_('Show your current IP address'), 'show-ip', new Gtk.Switch(), 'active'));
         group.add(this._actionRow(_('Show your VPN type (WireGuard/OpenVPN)'), 'show-type', new Gtk.Switch(), 'active'));
+
+        window.add(page);
     }
 
     _actionRow(title, key, object, property) {
@@ -77,11 +72,4 @@ class MullvadIndicatorPrefsWidget extends Adw.PreferencesPage {
 
         return row;
     }
-};
-
-function init() {
-}
-
-function buildPrefsWidget() {
-    return new MullvadIndicatorPrefsWidget();
 }


### PR DESCRIPTION
Ports the extension to GNOME 45, mostly involving updating the imports and removing the old `ExtensionUtils`. Also fixes the toggle appearing below "background apps."

Fixes #28 
Fixes #29 