### PR TITLE
Fix extension settings window not opening

### DIFF
--- a/locale/org.gnome.shell.extensions.MullvadIndicator.pot
+++ b/locale/org.gnome.shell.extensions.MullvadIndicator.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-18 18:23+0300\n"
+"POT-Creation-Date: 2023-12-22 12:57-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,94 +17,94 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: extension.js:18
+#: extension.js:22
 msgid "Initializing"
 msgstr ""
 
-#: extension.js:19 prefs.js:29
-msgid "Connected"
-msgstr ""
-
-#: extension.js:20
-msgid "Disconnected"
-msgstr ""
-
-#: extension.js:51 prefs.js:33
+#: extension.js:47 prefs.js:26
 msgid "Refresh"
 msgstr ""
 
-#: extension.js:58
+#: extension.js:54
 msgid "Settings"
 msgstr ""
 
-#: mullvad.js:10
-msgid "Server"
+#: extension.js:65 prefs.js:22
+msgid "Connected"
+msgstr ""
+
+#: extension.js:71
+msgid "Disconnected"
 msgstr ""
 
 #: mullvad.js:11
-msgid "Country"
+msgid "Server"
 msgstr ""
 
 #: mullvad.js:12
-msgid "City"
+msgid "Country"
 msgstr ""
 
 #: mullvad.js:13
-msgid "IP Address"
+msgid "City"
 msgstr ""
 
 #: mullvad.js:14
+msgid "IP Address"
+msgstr ""
+
+#: mullvad.js:15
 msgid "VPN Type"
 msgstr ""
 
-#: prefs.js:23
+#: prefs.js:16
 msgid "Visibility"
 msgstr ""
 
-#: prefs.js:27
+#: prefs.js:20
 msgid "Display indicator icon"
 msgstr ""
 
-#: prefs.js:28
+#: prefs.js:21
 msgid "Show in system menu"
 msgstr ""
 
-#: prefs.js:29
+#: prefs.js:22
 msgid "Title text"
 msgstr ""
 
-#: prefs.js:30
+#: prefs.js:23
 msgid "Subtitle text"
 msgstr ""
 
-#: prefs.js:30
+#: prefs.js:23
 msgid "None"
 msgstr ""
 
-#: prefs.js:41
+#: prefs.js:34
 msgid "Automatic refresh time (in seconds)"
 msgstr ""
 
-#: prefs.js:44
+#: prefs.js:37
 msgid "Status"
 msgstr ""
 
-#: prefs.js:48
+#: prefs.js:41
 msgid "Show currently connected server"
 msgstr ""
 
-#: prefs.js:49
+#: prefs.js:42
 msgid "Show currently connected server's country"
 msgstr ""
 
-#: prefs.js:50
+#: prefs.js:43
 msgid "Show currently connected server's city"
 msgstr ""
 
-#: prefs.js:51
+#: prefs.js:44
 msgid "Show your current IP address"
 msgstr ""
 
-#: prefs.js:52
+#: prefs.js:45
 msgid "Show your VPN type (WireGuard/OpenVPN)"
 msgstr ""

--- a/metadata.json
+++ b/metadata.json
@@ -8,5 +8,5 @@
   "url": "https://github.com/Pobega/gnome-shell-extension-mullvad-indicator",
   "settings-schema": "org.gnome.shell.extensions.MullvadIndicator",
   "gettext-domain": "mullvadindicator@pobega.github.com",
-  "version": 15.0
+  "version": 17
 }


### PR DESCRIPTION
Change the button signal to from 'button-press-event' to 'activate' and use Extension.openPreferences() since ExtensionUtils is deprecated as of Gnome 45.