### PR TITLE
Bump GNOME desktop version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,6 @@ zip:
 lint:
 	npx eslint . --ext .js --fix
 
-install:
+install: zip
 	mkdir -p ~/.local/share/gnome-shell/extensions/mullvadindicator\@pobega.github.com/
 	unzip mullvadindicator@pobega.github.com.zip -d ~/.local/share/gnome-shell/extensions/mullvadindicator\@pobega.github.com/

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,8 @@
   "description": "Mullvad connection status indicator",
   "uuid": "mullvadindicator@pobega.github.com",
   "shell-version": [
-    "45"
+    "45",
+    "46"
   ],
   "url": "https://github.com/Pobega/gnome-shell-extension-mullvad-indicator",
   "settings-schema": "org.gnome.shell.extensions.MullvadIndicator",


### PR DESCRIPTION
The extension is 46 compatible.

Fix also Makefile target dependencies, creating the zip file before
installing it, to avoid errors.
