### PR TITLE
Support Gnome 47

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,8 @@
   "description": "Mullvad connection status indicator",
   "uuid": "mullvadindicator@pobega.github.com",
   "shell-version": [
-    "46"
+    "46",
+    "47"
   ],
   "url": "https://github.com/Pobega/gnome-shell-extension-mullvad-indicator",
   "settings-schema": "org.gnome.shell.extensions.MullvadIndicator",


### PR DESCRIPTION
Gnome 47 is out, and the metadata needs to be updated. I am no longer a Mullvad subscribed so cannot test this on my machine without paying. If someone can swing by to let me know whether it works for them, I can merge and submit to extensions.gnome.org