### PR TITLE
ops: Add support for Gnome 48 (Fixes #38)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,10 +4,11 @@
   "uuid": "mullvadindicator@pobega.github.com",
   "shell-version": [
     "46",
-    "47"
+    "47",
+    "48"
   ],
   "url": "https://github.com/Pobega/gnome-shell-extension-mullvad-indicator",
   "settings-schema": "org.gnome.shell.extensions.MullvadIndicator",
   "gettext-domain": "mullvadindicator@pobega.github.com",
-  "version": 19
+  "version": 21
 }


### PR DESCRIPTION
### Changes  
- Added **Gnome 48** to the supported shell versions in `metadata.json`.  
- Incremented the extension version from `19` to `21` as the released package is already using version `20` on [Gnome Extensions](https://extensions.gnome.org/extension/3560/mullvad-indicator/).

### Context  
This update ensures compatibility with the latest Gnome Shell release (v48).  

Closes #38  