### PR TITLE
Added GNOME 49 to metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
   "shell-version": [
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "url": "https://github.com/Pobega/gnome-shell-extension-mullvad-indicator",
   "settings-schema": "org.gnome.shell.extensions.MullvadIndicator",


### PR DESCRIPTION
I tested briefly using GNOME on NixOS, briefly meaning I couldn't connect to test fully since my credit ran out, but it seems to load up and work fine!

Closes #40