### PR TITLE
Disconnect menu item activate signals on destroy

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -44,18 +44,24 @@ const MullvadToggle = GObject.registerClass({
 
     _buildBottomSection(mullvad) {
         // Item for manually checking connection to Mullvad
-        let refreshItem = new PopupMenu.PopupMenuItem(_('Refresh'));
-        refreshItem.actor.connect('activate', () => {
+        this._refreshItem = new PopupMenu.PopupMenuItem(_('Refresh'));
+        this._refreshSignal = this._refreshItem.actor.connect('activate', () => {
             mullvad._pollMullvad();
         });
-        this._bottomSection.addMenuItem(refreshItem);
+        this._bottomSection.addMenuItem(this._refreshItem);
 
         // Item for opening extension settings
-        let settingsItem = new PopupMenu.PopupMenuItem(_('Settings'));
-        settingsItem.actor.connect('activate', () => {
+        this._settingsItem = new PopupMenu.PopupMenuItem(_('Settings'));
+        this._settingsSignal = this._settingsItem.actor.connect('activate', () => {
             this._extension.openPreferences();
         });
-        this._bottomSection.addMenuItem(settingsItem);
+        this._bottomSection.addMenuItem(this._settingsItem);
+    }
+
+    destroy() {
+        this._refreshItem.actor.disconnect(this._refreshSignal);
+        this._settingsItem.actor.disconnect(this._settingsSignal);
+        super.destroy();
     }
 
     _sync(mullvad) {

--- a/extension.js
+++ b/extension.js
@@ -59,8 +59,16 @@ const MullvadToggle = GObject.registerClass({
     }
 
     destroy() {
-        this._refreshItem.actor.disconnect(this._refreshSignal);
-        this._settingsItem.actor.disconnect(this._settingsSignal);
+        if (this._refreshSignal) {
+            this._refreshItem.actor.disconnect(this._refreshSignal);
+            this._refreshSignal = null;
+        }
+        if (this._settingsSignal) {
+            this._settingsItem.actor.disconnect(this._settingsSignal);
+            this._settingsSignal = null;
+        }
+        this._refreshItem = null;
+        this._settingsItem = null;
         super.destroy();
     }
 
@@ -155,16 +163,18 @@ const MullvadIndicator = GObject.registerClass({
             ));
         }
 
-        this._signals.push(this._mullvad.connect(
+        this._mullvadSignal = this._mullvad.connect(
             'status-changed', () => {
                 this._sync();
             }
-        ));
+        );
     }
 
     _disconnectSignals() {
         for (let signal of this._signals)
             this._settings.disconnect(signal);
+
+        this._mullvad.disconnect(this._mullvadSignal);
     }
 
     _indicatorShouldBeVisible() {

--- a/metadata.json
+++ b/metadata.json
@@ -12,5 +12,5 @@
   "url": "https://github.com/Pobega/gnome-shell-extension-mullvad-indicator",
   "settings-schema": "org.gnome.shell.extensions.MullvadIndicator",
   "gettext-domain": "mullvadindicator@pobega.github.com",
-  "version": 23
+  "version": 25
 }


### PR DESCRIPTION
EGO-L-003 flagged the refresh/settings PopupMenuItem activate handlers as connected without matching disconnects. Save each signal id and disconnect both in a new MullvadToggle.destroy() override, which runs via the existing disable() -> destroy() -> _stop() chain.